### PR TITLE
Added Default AKS Policy 

### DIFF
--- a/deploy.ps1
+++ b/deploy.ps1
@@ -22,7 +22,7 @@ $azureReqs = @(
     @{
         Name     = "Azure Login"
         Describe = "Authenticate Azure Session"
-        Test     = { [Boolean] (az account show) }
+        Test     = { [boolean] (az account show) }
         Set      = { az login }
     },
     @{  # This could be done idempotently with a test,
@@ -155,6 +155,21 @@ $k8sReqs = @(
         Test     = { kubectl get hpa }
         Set      = {
             kubectl autoscale deployment pegasus --min=2 --max=5 --cpu-percent=80
+        }
+    },
+    @{
+        Name     = "Harden Cluster"
+        Describe = "Apply security policy"
+        Test = { kubectl get psp } # Improve tests
+        Set      = {
+            # Install the aks-preview extension
+            az extension add --name aks-preview
+
+            # Update the extension to make sure you have the latest version installed
+            az extension update --name aks-preview
+
+            # Apply default policy
+            az aks update --resource-group sbd --name sbd --enable-pod-security-policy
         }
     }
 )


### PR DESCRIPTION
Closes #6 

This is just step 1 of an infinite amount of security policy steps.  It prevents containers from running as privileged and probably breaks ssh or something.