### PR TITLE
Improved docker parsing

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,9 +16,9 @@ RUN apt-get update && apt-get -y install git procps jq apt-transport-https ca-ce
     && groupadd --gid $USER_GID $USERNAME \
     && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
     # [Optional] Uncomment the next three lines to add sudo support
-    #&& apt-get install -y sudo \
-    #&& echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
-    #&& chmod 0440 /etc/sudoers.d/$USERNAME \
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
     && curl -fsSL https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/gpg | apt-key add - 2>/dev/null \
     && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" \
     && apt-get update \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,9 @@
         "/var/run/docker.sock:/var/run/docker.sock"
     ],
     "extensions": [
-        "ms-vscode.powershell"
+        "ms-vscode.powershell",
+        "mauve.terraform",
+        "ms-azuretools.vscode-docker"
     ],
     "settings": {
         "remote.extensionKind": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,18 +3,17 @@
 {
     "name": "PowerShell",
     "dockerFile": "Dockerfile",
-    // Uncomment the next line if you want to publish any ports.
-    // "appPort": [],
-    // Uncomment the next line if you want to add in default container specific settings.json values
-    // "settings":  { "workbench.colorTheme": "Quiet Light" },
-    // Uncomment the next line to run commands after the container is created. This gets run in bash which is why we call `pwsh`.
-    // "postCreateCommand": "pwsh -c '$PSVersionTable'",
     // Uncomment the next line to use a non-root user. See https://aka.ms/vscode-remote/containers/non-root-user.
     // "runArgs": [ "-u", "1000" ],
     "runArgs": [
         "-v",
-        "/var/run/docker.sock:/var/run/docker.sock"
+        "/var/run/docker.sock:/var/run/docker.sock",
+        "-v",
+        "${env:HOME}${env:USERPROFILE}/.ssh:/root/.ssh-localhost:ro",
+        "-u",
+        "1000"
     ],
+    "postCreateCommand": "mkdir -p ~/.ssh && cp -r ~/.ssh-localhost/* ~/.ssh && chmod 700 ~/.ssh && chmod 600 ~/.ssh/*",
     "extensions": [
         "ms-vscode.powershell",
         "mauve.terraform",
@@ -23,6 +22,7 @@
     "settings": {
         "remote.extensionKind": {
             "ms-azuretools.vscode-docker": "workspace"
-        }
+        },
+        "workbench.colorTheme": "Quiet Light"
     }
 }

--- a/.test/data/test.dockerfile
+++ b/.test/data/test.dockerfile
@@ -1,2 +1,3 @@
-
-ECHO "hello world"
+FROM alpine
+RUN echo "hello world"
+EXPOSE 8888

--- a/.test/scripts/jaw.tests.ps1
+++ b/.test/scripts/jaw.tests.ps1
@@ -7,7 +7,7 @@ Describe "Set-K8sConfig" {
     BeforeAll {
         Import-Module $RepoRoot/modules/jaw
         New-Item -Path $OutRoot -ItemType Directory -Force
-        docker build -t "mics233.azurecr.io/data" "$RepoRoot/.test/data" -f "$RepoRoot/.test/data/test.dockerfile"
+        docker build -t "mics233.azurecr.io/data" "./.test/data" -f "./.test/data/test.dockerfile"
         Set-K8sConfig -AppPath "$ScriptsRoot/../data" -OutPath $OutRoot
     }
     AfterAll {

--- a/.test/scripts/jaw.tests.ps1
+++ b/.test/scripts/jaw.tests.ps1
@@ -7,6 +7,7 @@ Describe "Set-K8sConfig" {
     BeforeAll {
         Import-Module $RepoRoot/modules/jaw
         New-Item -Path $OutRoot -ItemType Directory -Force
+        docker build -t "mics233.azurecr.io/data" "$RepoRoot/.test/data" -f "$RepoRoot/.test/data/test.dockerfile"
         Set-K8sConfig -AppPath "$ScriptsRoot/../data" -OutPath $OutRoot
     }
     AfterAll {

--- a/.test/scripts/jaw.tests.ps1
+++ b/.test/scripts/jaw.tests.ps1
@@ -16,7 +16,7 @@ Describe "Set-K8sConfig" {
         Test-Path "$OutRoot/k8s.json" | Should -BeTrue
     }
     It "Json should contain string" {
-        Get-Content "$OutRoot/k8s.json" -Raw | Should -Match "hello"
+        Get-Content "$OutRoot/k8s.json" -Raw | Should -Match "data"
     }
     It "Parses back to an Object" {
         Get-Content "$OutRoot/k8s.json" -Raw | ConvertFrom-Json | Select "Name" | Should -Match "test.dockerfile"
@@ -34,7 +34,7 @@ Describe "Expand-Template" {
         | Out-File "$OutRoot\test.yml"
     }
     AfterAll {
-        Remove-Item $OutRoot -Recurse -Force
+        #Remove-Item $OutRoot -Recurse -Force
     }
     It "Should create a yaml" {
         Test-Path "$OutRoot/test.yml" | Should -BeTrue

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
   "recommendations": [
     "ms-vscode.powershell",
     "mauve.terraform",
-    "ms-azuretools.vscode-docker"
+    "ms-azuretools.vscode-docker",
+    "ms-vscode-remote.remote-containers"
   ]
 }

--- a/deploy.ps1
+++ b/deploy.ps1
@@ -129,7 +129,7 @@ $k8sReqs = @(
                     "deploy_name" = "pegasus"
                     "image_name"  = $_.ImageName
                     "cr_name"     = $acr_name
-                    "port"        = 80
+                    "port"        = $_.Ports
                 }
                 Expand-Template -Template $deploy_template -Data $deploy_data | Out-File $OutputDir/pod.yml -Append
                 "---" | Out-File $OutputDir/pod.yml -Append
@@ -137,7 +137,7 @@ $k8sReqs = @(
 
             $service_data = @{
                 "service_name" = "pegasus"
-                "port"         = 80
+                "port"         = 80 # This needs to enforce 443 - See issue #41
             }
             Expand-Template -Template $service_template -Data $service_data | Out-File $OutputDir/pod.yml -Append
         }
@@ -160,7 +160,7 @@ $k8sReqs = @(
     @{
         Name     = "Harden Cluster"
         Describe = "Apply security policy"
-        Test = { kubectl get psp } # Improve tests
+        Test     = { kubectl get psp } # Improve tests
         Set      = {
             # Install the aks-preview extension
             az extension add --name aks-preview

--- a/modules/jaw/jaw.psm1
+++ b/modules/jaw/jaw.psm1
@@ -58,6 +58,7 @@ function Set-k8sConfig {
     # Extract port numbers out of config
     $Ports = ($Config | ConvertFrom-Json -AsHashtable).ExposedPorts.Keys | % { ($_ -split "/")[0] }
 
+    # Build a model for serialization
     [Docker] @{
       Name      = $Name
       ImageName = $ImageName

--- a/modules/jaw/jaw.psm1
+++ b/modules/jaw/jaw.psm1
@@ -2,11 +2,11 @@ $ErrorActionPreference = "Stop"
 
 # Class to hold Docker structure
 class Docker {
-    [string] $Name
-    [string] $ImageName
-    [string] $Path
-    [string[]] $Ports
-    [boolean] $Frontend # To identify which port serves traffic
+  [string] $Name
+  [string] $ImageName
+  [string] $Path
+  [string[]] $Ports
+  [boolean] $Frontend # To identify which port serves traffic
 }
 
 <#
@@ -16,19 +16,19 @@ class Docker {
   Works on any type of config.  Replaces "{{varname}}" => $varname.
 #>
 function Expand-Template {
-    [CmdletBinding()]
-    [OutputType([String])]
-    Param(
-        [Parameter(Mandatory)]
-        [ValidateNotNullOrEmpty()]
-        [string] $Template,
-        [Parameter(Mandatory)]
-        [hashtable] $Data
-    )
+  [CmdletBinding()]
+  [OutputType([String])]
+  Param(
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string] $Template,
+    [Parameter(Mandatory)]
+    [hashtable] $Data
+  )
 
-    $instance = $Template
-    $data.keys | % { $instance = $instance -replace "{{$_}}", $Data[$_] }
-    $instance
+  $instance = $Template
+  $data.keys | % { $instance = $instance -replace "{{$_}}", $Data[$_] }
+  $instance
 }
 
 <#
@@ -38,29 +38,34 @@ function Expand-Template {
   Searches for dockerfiles and saves information about them for later use.
 #>
 function Set-k8sConfig {
-    [CmdletBinding(SupportsShouldProcess = $true)]
-    param(
-        [string] $AppPath,
-        [string] $OutPath
-    )
-    # parse each Dockerfile in to a K8S JSON
-    # we only check for top level dockerfiles right now.
-    Get-ChildItem -Path $AppPath -Filter "*dockerfile*" -Recurse `
-    | % {
-        $Name = $_.FullName
-        $Path = $_.Directory
-        $ImageName = ($Path -split "/")[-1]
-        $Ports = docker inspect mics233.azurecr.io/$ImageName --format="{{json .Config}}"
-        $Ports = ($Ports | ConvertFrom-Json -AsHashtable).ExposedPorts.Keys | % { ($_ -split "/")[0] }
+  [CmdletBinding(SupportsShouldProcess = $true)]
+  param(
+    [string] $AppPath,
+    [string] $OutPath
+  )
+  # parse each Dockerfile in to a K8S JSON
+  # we only check for top level dockerfiles right now.
+  Get-ChildItem -Path $AppPath -Filter "*dockerfile*" -Recurse `
+  | % {
+    # Full File Name
+    $Name = $_.FullName
+    # Parent Directory
+    $Path = $_.Directory
+    # This resolves to the folder directly beneath /app
+    $ImageName = ($Path -split "/")[-1]
+    # Query inactive container for config
+    $Config = docker inspect mics233.azurecr.io/$ImageName --format="{{json .Config}}"
+    # Extract port numbers out of config
+    $Ports = ($Config | ConvertFrom-Json -AsHashtable).ExposedPorts.Keys | % { ($_ -split "/")[0] }
 
-        [Docker] @{
-            Name      = $Name
-            ImageName = $ImageName
-            Path      = $Path
-            Ports     = $Ports
-            Frontend  = $false
-        }
-    } `
-    | ConvertTo-Json `
-    | Out-File "$OutPath/k8s.json"
+    [Docker] @{
+      Name      = $Name
+      ImageName = $ImageName
+      Path      = $Path
+      Ports     = $Ports
+      Frontend  = $false
+    }
+  } `
+  | ConvertTo-Json `
+  | Out-File "$OutPath/k8s.json"
 }

--- a/modules/jaw/jaw.psm1
+++ b/modules/jaw/jaw.psm1
@@ -48,8 +48,8 @@ function Set-k8sConfig {
     Get-ChildItem -Path $AppPath -Filter "*dockerfile*" -Recurse `
     | % {
         $Name = $_.FullName
-        $ImageName = (($Name -Split "/app/")[1] -Split "/")[0]
         $Path = $_.Directory
+        $ImageName = ($Path -split "/")[-1]
         $Ports = docker inspect mics233.azurecr.io/$ImageName --format="{{json .Config}}"
         $Ports = ($Ports | ConvertFrom-Json -AsHashtable).ExposedPorts.Keys | % { ($_ -split "/")[0] }
 

--- a/modules/jaw/jaw.psm1
+++ b/modules/jaw/jaw.psm1
@@ -48,7 +48,7 @@ function Set-k8sConfig {
     Get-ChildItem -Path $AppPath -Filter "*dockerfile*" -Recurse `
     | % {
         $Name = $_.FullName
-        $ImageName = $Name.Split("/")[4].ToLower()
+        $ImageName = (($Name -Split "/app/")[1] -Split "/")[0]
         $Path = $_.Directory
         $Ports = docker inspect mics233.azurecr.io/$ImageName --format="{{json .Config}}"
         $Ports = ($Ports | ConvertFrom-Json -AsHashtable).ExposedPorts.Keys | % { ($_ -split "/")[0] }


### PR DESCRIPTION
We previously were parsing port numbers out of dockerfiles that we found.  This was not smart parsing and just made pairs out of commands we found in there.  It wasn't super scalable and was a little cryptic.

This switches over to using `docker inspect` formating to parse out ports exposed from the actual container that was built.  This has the added benefit of discovering ports exposed in base containers that may not actually be in dockerfiles we have access too.  Yay!

In the future if we need some information from the container we already have built, this is a good pattern to follow.